### PR TITLE
fix(rafiki): expose frontend service

### DIFF
--- a/modules/rafiki/frontend.nix
+++ b/modules/rafiki/frontend.nix
@@ -92,6 +92,21 @@ with k8s;
                         };
                     };
                 };
+
+                services.rafiki-frontend = {
+                    metadata = {
+                        name = name;
+                        labels.app = name;
+                    };
+
+                    spec = {
+                        selector.app = name;
+
+                        ports = [
+                            { name = "http"; port = 3010; targetPort = 3010; }
+                        ];
+                    };
+                };
             };
         };
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a dedicated frontend service, exposing HTTP on port 3010 for easier access and integration.
- Bug Fixes
  - Specified the target port (3010) to align with the application’s listening port, ensuring reliable traffic routing and preventing connection issues.
- Chores
  - Standardized service metadata and labels for clearer identification and management within the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->